### PR TITLE
Switch to a formatter system that filters log messages at the point o…

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = False
 tag = False
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "velatus"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "log",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "velatus"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ INFO:root:Printing out [MASKED], [MASKED]
 
 ## Design
 
-velatus consists of a `Masker` class which is callable and written in Rust using pyo3. It may be installed as a filter on a logging Handler with `addFilter`.
+velatus ships a `SecretFormatter` implemented in Rust with pyo3. It wraps any existing `logging.Formatter`, so you can attach it to handlers via `setFormatter` without losing their formatting configuration.
 
-Under the covers, the `Masker` compiles the set of strings to a regular expression using the `regex` library, then substitutes all matches with the configured masking value.
+Under the covers, the `SecretFormatter` compiles the set of strings into a single regular expression using the `regex` crate, then substitutes every match with `[MASKED]` (or a custom replacement if you provide one).
+
+To mask secrets in uncaught exceptions as well, call `velatus.mask_exceptions(secrets)` after installing the handler formatter. This replaces `sys.excepthook` so tracebacks written to stderr are redacted before they reach the console or logs.

--- a/python/tests/test_all.py
+++ b/python/tests/test_all.py
@@ -1,6 +1,8 @@
-"""Test the Masker class with different parameters."""
+"""Tests for the SecretFormatter implementation."""
 
+import io
 import logging
+import sys
 from typing import Any
 
 import pytest
@@ -22,85 +24,103 @@ def make_log_record(msg: Any) -> logging.LogRecord:
     )
 
 
-@pytest.mark.parametrize(
-    "mask, strings_to_mask, log_record, expected",
-    [
-        (
-            None,
-            ["xxx", "yyy"],
-            "This is a log message with secret xxx and yyy",
-            "This is a log message with secret [MASKED] and [MASKED]",
-        ),
-        (
-            "[REDACTED]",
-            ["xxx", "yyy"],
-            "This is a log message with secret xxx and yyy",
-            "This is a log message with secret [REDACTED] and [REDACTED]",
-        ),
-        (
-            None,
-            ["$TEST"],
-            "This is a test message with $TEST",
-            "This is a test message with [MASKED]",
-        ),
-        (
-            None,
-            ["[A-Z]"],
-            "This [A-Z] is a test message with [A-Z]",
-            "This [MASKED] is a test message with [MASKED]",
-        ),
-        (
-            None,
-            ["\\"],
-            "This is a test message with \\ and \\",
-            "This is a test message with [MASKED] and [MASKED]",
-        ),
-        (
-            None,
-            ["xyz"],
-            "This is a test message without a secret",
-            "This is a test message without a secret",
-        )
-    ],
-)
-def test_masker(mask, strings_to_mask, log_record, expected):
-    """Test the Masker class with different parameters."""
-    m = velatus.Masker(strings_to_mask, mask=mask)
+def test_secret_formatter_masks_message() -> None:
+    """SecretFormatter should redact configured secrets."""
+    formatter = velatus.SecretFormatter(
+        secrets=["xxx", "yyy"],
+        existing_formatter=logging.Formatter("%(message)s"),
+    )
 
-    # Use the masker to mask the log record
-    llr = make_log_record(log_record)
+    record = make_log_record("This is a log message with secret xxx and yyy")
+    masked = formatter.format(record)
 
-    log.info(f"Original log record: {llr.msg}")
-    m(llr)
-    log.info(f"Masked log record: {llr.msg}")
-
-    # Check if the log record message is masked
-    assert llr.msg == expected
+    assert masked == "This is a log message with secret [MASKED] and [MASKED]"
 
 
-def test_empty_list() -> None:
-    """Test the Masker with an empty list."""
-    with pytest.raises(ValueError):
-        velatus.Masker([])
+def test_secret_formatter_custom_mask() -> None:
+    """SecretFormatter should support a constant replacement mask."""
+    formatter = velatus.SecretFormatter(
+        secrets=["xxx"],
+        mask="[REDACTED]",
+        existing_formatter=logging.Formatter("%(message)s"),
+    )
 
-def test_bytes() -> None:
-    """Test that the Masker can handle bytes in the LogRecord."""
-    m = velatus.Masker(["xxx", "yyy"])
-    llr = make_log_record(b"This is a log message with secret xxx and yyy")
-    m(llr)
-    assert llr.msg == "This is a log message with secret [MASKED] and [MASKED]"
+    record = make_log_record("Secret value xxx present")
+    masked = formatter.format(record)
+    assert masked == "Secret value [REDACTED] present"
 
-def test_weird_record() -> None:
-    """Test that the Masker can handle objects in the LogRecord."""
-    m = velatus.Masker(["xxx", "yyy"])
+
+def test_secret_formatter_bytes_message() -> None:
+    """SecretFormatter should handle byte messages."""
+    formatter = velatus.SecretFormatter(
+        secrets=["xxx"],
+        existing_formatter=logging.Formatter("%(message)s"),
+    )
+
+    record = make_log_record(b"Secret value xxx present")
+    masked = formatter.format(record)
+    # The underlying formatter converts the bytes to a string with the b'' prefix
+    assert masked == "b'Secret value [MASKED] present'"
+
+
+def test_secret_formatter_weird_object() -> None:
+    """SecretFormatter should handle arbitrary objects."""
 
     class WeirdObject:
-        """A weird object for testing purposes."""
-
         def __str__(self) -> str:
-            """Return a string representation of the object."""
-            return "This is a weird object with secret xxx and yyy"
+            return "Weird object with xxx"
 
-    llr = make_log_record(WeirdObject())
-    m(llr)
-    assert llr.msg == "This is a weird object with secret [MASKED] and [MASKED]"
+    formatter = velatus.SecretFormatter(
+        secrets=["xxx"],
+        existing_formatter=logging.Formatter("%(message)s"),
+    )
+
+    record = make_log_record(WeirdObject())
+    masked = formatter.format(record)
+    assert masked == "Weird object with [MASKED]"
+
+
+def test_secret_formatter_requires_secret() -> None:
+    """SecretFormatter should raise when no secrets are provided."""
+    with pytest.raises(ValueError):
+        velatus.SecretFormatter(secrets=[])
+
+
+def test_mask_handlers_installs_formatter() -> None:
+    """mask_handlers should wrap handlers with SecretFormatter."""
+    handler = logging.StreamHandler(io.StringIO())
+
+    velatus.mask_handlers(["xxx"], [handler])
+
+    assert isinstance(handler.formatter, velatus.SecretFormatter)
+
+    record = make_log_record("Contains xxx value")
+    formatted = handler.format(record)
+    assert formatted == "Contains [MASKED] value"
+
+
+def test_mask_handlers_requires_secrets() -> None:
+    """mask_handlers should reject empty secret lists."""
+    with pytest.raises(ValueError):
+        velatus.mask_handlers([], [])
+
+
+def test_mask_exceptions_masks_sys_excepthook() -> None:
+    """mask_exceptions should redact secrets written by sys.excepthook."""
+    original_hook = sys.excepthook
+    original_stderr = sys.stderr
+
+    try:
+        velatus.mask_exceptions(["supersecret"])
+
+        buffer = io.StringIO()
+        sys.stderr = buffer
+
+        sys.excepthook(ValueError, ValueError("supersecret"), None)
+
+        output = buffer.getvalue()
+        assert "[MASKED]" in output
+        assert "supersecret" not in output
+    finally:
+        sys.stderr = original_stderr
+        sys.excepthook = original_hook

--- a/python/velatus/__init__.py
+++ b/python/velatus/__init__.py
@@ -1,21 +1,43 @@
 """Velatus: A Python library for masking sensitive information in logs."""
 
 import logging
+import sys
 from typing import Optional
 
-from .velatus import Masker
+from .velatus import SecretFormatter
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 def mask_handlers(
     secrets: list[str], handlers: list[logging.Handler], mask: Optional[str] = None
 ) -> None:
-    """Install a Masker as a filter on all given handlers."""
-    # Create a Masker instance
-    masker = Masker(secrets, mask=mask)
+    """Install a SecretFormatter on all given handlers."""
+    if not secrets:
+        raise ValueError("At least one secret must be provided")
 
-    # Iterate through all handlers
     for handler in handlers:
-        handler.addFilter(masker)
+        existing_formatter = handler.formatter
+        formatter = SecretFormatter(
+            secrets=secrets,
+            mask=mask,
+            existing_formatter=existing_formatter,
+        )
+        handler.setFormatter(formatter)
+
+def mask_exceptions(secrets: list[str], mask: Optional[str] = None) -> None:
+    """Install a SecretFormatter as sys.excepthook."""
+    if not secrets:
+        raise ValueError("At least one secret must be provided")
+    exc_formatter = SecretFormatter(secrets=secrets, mask=mask)
+    sys.excepthook = exc_formatter.handle_exception
 
 
-__all__ = ["Masker", "mask_handlers", "__doc__"]
+
+__all__ = [
+    "SecretFormatter",
+    "mask_handlers",
+    "mask_exceptions",
+    "__doc__",
+]

--- a/python/velatus/velatus.pyi
+++ b/python/velatus/velatus.pyi
@@ -1,8 +1,23 @@
 import logging
+from types import TracebackType
+from typing import Any
 
-class Masker:
-    """A class to mask sensitive information in log records."""
 
-    def __init__(self, strings: list[str], mask: str | None = None) -> None: ...
+class SecretFormatter(logging.Formatter):
+    """Formatter that masks sensitive information in log messages."""
 
-    def __call__(self, log_record: logging.LogRecord) -> bool: ...
+    def __init__(
+        self,
+        secrets: list[str],
+        mask: str | None = None,
+        existing_formatter: logging.Formatter | None = None,
+    ) -> None: ...
+
+    def format(self, record: logging.LogRecord) -> str: ...
+
+    def handle_exception(
+        self,
+        exc_type: type[BaseException],
+        exc_value: BaseException,
+        exc_traceback: TracebackType | None,
+    ) -> None: ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,87 +1,143 @@
 use std::borrow::Cow;
 
 use log::debug;
-use pyo3::{prelude::*, types::{PyBytes, PyString}};
+use pyo3::{prelude::*, types::PyString};
 use regex::{escape, Regex};
 
-// Create a callable class that stores a masking regex
+// Create a logging Formatter that masks secrets.
 #[pyclass]
-struct Masker {
+struct SecretFormatter {
     regex: Regex,
+    formatter: Py<PyAny>,
     mask: String,
 }
 
 #[pymethods]
-impl Masker {
-    /// Create a new Masker instance.
+impl SecretFormatter {
+    /// Create a new SecretFormatter instance.
     #[new]
-    #[pyo3(signature = (strings, mask=None))]
-    pub fn new(strings: Vec<Bound<PyString>>, mask: Option<Bound<PyString>>) -> PyResult<Self> {
-        // Convert the PyString objects to Rust strings, escaping them for regex
-        let res: PyResult<Vec<String>> = strings
+    #[pyo3(signature = (secrets, mask=None, existing_formatter=None))]
+    pub fn new(
+        py: Python<'_>,
+        secrets: Vec<Bound<PyString>>,
+        mask: Option<String>,
+        existing_formatter: Option<Py<PyAny>>,
+    ) -> PyResult<Self> {
+        Self::construct(py, secrets, mask, existing_formatter)
+    }
+
+    /// Format the log record and mask secrets in the resulting message.
+    pub fn format(&self, py: Python<'_>, record: Bound<PyAny>) -> PyResult<String> {
+        // Format the log record using the underlying formatter
+        let formatter = self.formatter.bind(py);
+        let formatted = formatter
+            .call_method1("format", (record,))?
+            .unbind();
+        let formatted = formatted.bind(py);
+
+        // Get the formatted message as a string
+        let message = if let Ok(string) = formatted.downcast::<PyString>() {
+            string.extract::<String>()?
+        } else {
+            // The response from the formatter should be a string, but if it's not, fall back to calling str()
+            formatted.str()?.extract::<String>()?
+        };
+
+        Ok(self.redact(message))
+    }
+
+    /// Redact secrets from exceptions and write the traceback to stderr.
+    pub fn handle_exception(
+        &self,
+        py: Python<'_>,
+        exc_type: Bound<PyAny>,
+        exc_value: Bound<PyAny>,
+        exc_traceback: Option<Bound<PyAny>>,
+    ) -> PyResult<()> {
+        let original_message = exc_value.str()?.extract::<String>()?;
+        let redacted_message = self.redact(original_message);
+        let redacted_exception = exc_type.call1((redacted_message.clone(),))?;
+
+        let traceback_module = py.import("traceback")?;
+
+        let tb_lines: Vec<String> = traceback_module
+            .call_method1(
+                "format_exception",
+                (exc_type, redacted_exception, exc_traceback),
+            )?
+            .extract()?;
+
+        let joined = tb_lines.join("");
+        let sys_module = py.import("sys")?;
+        let stderr = sys_module.getattr("stderr")?;
+        stderr.call_method1("write", (joined,))?;
+
+        Ok(())
+    }
+}
+
+impl SecretFormatter {
+    fn construct(
+        py: Python<'_>,
+        secrets: Vec<Bound<PyString>>,
+        mask: Option<String>,
+        existing_formatter: Option<Py<PyAny>>,
+    ) -> PyResult<Self> {
+        let escaped: PyResult<Vec<String>> = secrets
             .into_iter()
             .map(|s| s.extract::<&str>().map(escape))
             .collect();
 
-        let strings: Vec<String> = res?;
+        let secrets = escaped?;
 
-        // Fail if no strings are provided
-        if strings.is_empty() {
+        if secrets.is_empty() {
             return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                "At least one string must be provided",
+                "At least one secret must be provided",
             ));
         }
 
-        debug!("Creating masker for {} strings", strings.len());
+        debug!("Creating secret formatter for {} secrets", secrets.len());
 
-        // If a mask is provided, use it; otherwise, default to [MASKED]
-        let mask = match mask {
-            Some(m) => m.extract::<String>()?,
-            None => "[MASKED]".to_string(),
+        let pattern = secrets.join("|");
+
+        let pattern = format!("({pattern})");
+        let regex = Regex::new(&pattern)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+
+        let formatter = match existing_formatter {
+            Some(f) => f,
+            None => {
+                let logging = py.import("logging")?;
+                logging
+                    .getattr("Formatter")?
+                    .call0()?
+                    .unbind()
+            }
         };
 
-        // Join the strings with '|' to create a regex pattern
-        let pattern = format!("({})", strings.join("|"));
-        let regex = Regex::new(&pattern)
-            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("{}", e)))?;
-
-        Ok(Masker { regex, mask })
+        Ok(SecretFormatter {
+            regex,
+            formatter,
+            mask: mask.unwrap_or_else(|| "[MASKED]".to_string()),
+        })
     }
 
-    /// Mask the log record's message using the regex.
-    pub fn __call__(&self, log_record: Bound<PyAny>) -> PyResult<bool> {
-        // The log_record is expected to be a logging.LogRecord object
-        // Extract the message from the log_record
-        let msg_attr = log_record.getattr("msg")?;
-
-        let msg = if let Ok(string) = msg_attr.downcast::<PyString>() {
-            // If the message is a string, extract it directly
-            string.extract::<String>()?
-        } else if let Ok(bytes) = msg_attr.downcast::<PyBytes>() {
-            // If the message is a bytes object, decode it to a string and extract it
-            // This is necessary because the regex operates on strings
-            bytes.call_method1("decode", ("utf-8",))?.extract::<String>()?
-        }
-        else {
-            // If the message is neither a string nor bytes, call str() on the object
-            msg_attr.call_method0("__str__")?.extract::<String>()?
-        };
-
+    fn redact(&self, message: String) -> String {
         // Replace any regex matches with the mask
         //
         // Rely on the fact that regex::Regex::replace_all returns
         // Cow::Borrowed if no matches are found, and Cow::Owned if matches are found
         // to be faster against normal lines which need no masking
-        match self.regex.replace_all(&msg, &self.mask) {
+        match self.regex.replace_all(&message, &self.mask) {
             Cow::Borrowed(_) => {
                 // No matches found, do nothing
+                message
             },
             Cow::Owned(masked_msg) => {
-                // Set the masked message back to the log_record
-                log_record.setattr("msg", masked_msg)?;
+                // Return the replacement string.
+                masked_msg
             }
         }
-        Ok(true)
     }
 }
 
@@ -89,6 +145,6 @@ impl Masker {
 #[pymodule]
 fn velatus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     pyo3_log::init();
-    m.add_class::<Masker>()?;
+    m.add_class::<SecretFormatter>()?;
     Ok(())
 }


### PR DESCRIPTION
This pull request introduces a major refactor to the Python and Rust codebase, replacing the old `Masker` class with a new `SecretFormatter` class for masking secrets in log messages. The new design integrates secret masking directly into Python's logging `Formatter` interface, supports masking in exception tracebacks, and updates all relevant tests and documentation. The Rust extension is also significantly refactored to support the new interface.

The most important changes are:

**API and Design Overhaul:**

* Replaces the `Masker` class with a new `SecretFormatter` class, which is now a logging `Formatter` that masks secrets in log messages and exception tracebacks. `SecretFormatter` can wrap any existing formatter and is installable via `setFormatter`, preserving formatting configuration. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L4-R148)], [[2]](diffhunk://#diff-aa5db4aa7b0bd249c6bce594e1700081b450f04d008997e95327aee80d2dddbcR4-R43)], [[3]](diffhunk://#diff-70766ce9db78470e7c5a9bdf9e160c73e6f41a17e18f17a756b87de0657e4ab4R2-R23)], [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R35)])
* Adds the `mask_exceptions` function to redact secrets from uncaught exceptions by replacing `sys.excepthook`. [[1]](diffhunk://#diff-aa5db4aa7b0bd249c6bce594e1700081b450f04d008997e95327aee80d2dddbcR4-R43)], [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L4-R148)])

**Python Interface and Testing:**

* Updates the `mask_handlers` function to install `SecretFormatter` on handlers instead of using a filter, and adds input validation for secrets. ([[python/velatus/__init__.pyR4-R43](diffhunk://#diff-aa5db4aa7b0bd249c6bce594e1700081b450f04d008997e95327aee80d2dddbcR4-R43)])
* Completely rewrites the test suite in `test_all.py` to test `SecretFormatter` functionality, including masking of strings, bytes, arbitrary objects, handler installation, and exception masking. [[1]](diffhunk://#diff-690bda6baf2a8583daa5e638f370116aa588a58ca3093996c792f587423f9798L25-R126)], [[2]](diffhunk://#diff-690bda6baf2a8583daa5e638f370116aa588a58ca3093996c792f587423f9798L1-R5)])

**Rust Extension Refactor:**

* Refactors the Rust implementation to provide the new `SecretFormatter` class, with methods for formatting log records and handling exceptions, and removes the old `Masker` logic. ([[src/lib.rsL4-R148](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L4-R148)])
* Improves error handling and validation in the Rust code, ensuring at least one secret is provided and supporting custom masks and formatter chaining. ([[src/lib.rsL4-R148](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L4-R148)])

**Documentation and Versioning:**

* Updates the documentation in `README.md` to describe the new `SecretFormatter` class and its usage, including exception masking. ([[README.mdL31-R35](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R35)])
* Bumps the version to `0.4.0` in both `.bumpversion.cfg` and `Cargo.toml` to reflect the breaking API change. [[1]](diffhunk://#diff-9ea6e1e3dde6d4a7e08c7c88eceed69ca745d0d2c779f8f85219b22266efff7fL2-R2)], [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3)])